### PR TITLE
Bug fix: _readContactValue() catch handlers used unresolved symbol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the GPIO numbers from the [RPi Low-level peripherals wiki page](http://elinu
 Device examples
 ---------------
 
-###GpioSwitch Device
+### GpioSwitch Device
 
     { 
       "id": "led-light",
@@ -33,7 +33,7 @@ Device examples
       "gpio": 17 
     }
 
-###GpioPresence Sensor
+### GpioPresence Sensor
 
     { 
       "id": "presence-sensor",
@@ -42,7 +42,7 @@ Device examples
       "gpio": 18 
     }
 
-###GpioContact Sensor
+### GpioContact Sensor
 
     { 
       "id": "contact-sensor",

--- a/gpio.coffee
+++ b/gpio.coffee
@@ -75,8 +75,8 @@ module.exports = (env) ->
       @_contact = lastState?.contact?.value or false
 
       @_readContactValue().catch( (error) =>
-        env.logger.error err.message
-        env.logger.debug err.stack
+        env.logger.error error.message
+        env.logger.debug error.stack
       )
 
       @gpio.watch (err, value) =>
@@ -111,8 +111,8 @@ module.exports = (env) ->
       @_presence = lastState?.presence?.value or false
 
       @_readPresenceValue().catch( (error) =>
-        env.logger.error err.message
-        env.logger.debug err.stack
+        env.logger.error error.message
+        env.logger.debug error.stack
       )
 
       @gpio.watch (err, value) =>


### PR DESCRIPTION
Added extra space to ### formatting markup to allow for proper rendering on npmjs